### PR TITLE
Use Python 3.13 in macOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
                 macos_version: ["13", "14"]
                 compiler:
                     - { name: clang, c: clang, cxx: clang++ }
-                python_version: ["3.12"]
+                python_version: ["3.13"]
             fail-fast: false
 
         runs-on: macos-${{ matrix.macos_version }}


### PR DESCRIPTION
GDAL now built against 3.13