### PR TITLE
Fix typo in `sqrt` of `lue.pcraster` Python subpackage

### DIFF
--- a/environment/configuration/requirements-dev.txt
+++ b/environment/configuration/requirements-dev.txt
@@ -1,7 +1,7 @@
 breathe==4.35.0
 conan==2.4.1
 docopt==0.6.2
-jinja2==3.1.4
+jinja2==3.1.5
 matplotlib==3.9.0
 mypy==1.10.1
 types-python-dateutil==2.9.0.20241003

--- a/source/framework/python/pcraster/__init__.py
+++ b/source/framework/python/pcraster/__init__.py
@@ -1120,7 +1120,7 @@ def sqr(expression):
 
 
 def sqrt(expression):
-    return lfr.log(expression)
+    return lfr.sqrt(expression)
 
 
 def streamorder(*args):


### PR DESCRIPTION
Closes #768 